### PR TITLE
Add FFMpeg HTTP Live Streaming support

### DIFF
--- a/Config/StreamingProfiles.xml
+++ b/Config/StreamingProfiles.xml
@@ -441,6 +441,133 @@
         <httpLiveRemoveOld>5</httpLiveRemoveOld>
       </TranscoderParameters>
     </TranscoderProfile>
+    <TranscoderProfile>
+      <Name>FFmpeg HTTP Live Streaming HD</Name>
+      <Description>HD-quality HTTP Live Streaming profile based on ffmpeg</Description>
+      <Bandwidth>2280</Bandwidth>
+      <Targets>
+        <Target>android</Target>
+        <Target>ios</Target>
+        <Target>mobile-hls-video</Target>
+      </Targets>
+      <Transport>httplive</Transport>
+      <MaxOutputWidth>1280</MaxOutputWidth>
+      <MaxOutputHeight>720</MaxOutputHeight>
+      <MIME>video/MP2T</MIME>
+      <HasVideoStream>true</HasVideoStream>
+
+      <Transcoder>MPExtended.Services.StreamingService.Transcoders.FFMpegWrapperHTTPLiveStreaming</Transcoder>
+      <TranscoderParameters>
+        <codecParameters>-codec:v libx264 -b:v 1768k -profile:v baseline -preset:v faster -coder rle -keyint_min 25 -g 25 -codec:a aac -b:a 512k -ac 2 -strict experimental -async 1 -sn -f segment -segment_list_flags +live -segment_time 5</codecParameters>
+        <httpLiveRemoveOld>5</httpLiveRemoveOld>
+      </TranscoderParameters>
+    </TranscoderProfile>
+    <TranscoderProfile>
+      <Name>FFmpeg HTTP Live Streaming ultra HQ</Name>
+      <Description>Ultra high-quality HTTP Live Streaming profile based on ffmpeg</Description>
+      <Bandwidth>1280</Bandwidth>
+      <Targets>
+        <Target>android</Target>
+        <Target>ios</Target>
+        <Target>mobile-hls-video</Target>
+      </Targets>
+      <Transport>httplive</Transport>
+      <MaxOutputWidth>800</MaxOutputWidth>
+      <MaxOutputHeight>600</MaxOutputHeight>
+      <MIME>video/MP2T</MIME>
+      <HasVideoStream>true</HasVideoStream>
+
+      <Transcoder>MPExtended.Services.StreamingService.Transcoders.FFMpegWrapperHTTPLiveStreaming</Transcoder>
+      <TranscoderParameters>
+        <codecParameters>-codec:v libx264 -b:v 1024k -profile:v baseline -preset:v veryfast -coder rle -keyint_min 25 -g 25 -codec:a aac -b:a 256k -ac 2 -strict experimental -async 1 -sn -f segment -segment_list_flags +live -segment_time 5</codecParameters>
+        <httpLiveRemoveOld>5</httpLiveRemoveOld>
+      </TranscoderParameters>
+    </TranscoderProfile>
+    <TranscoderProfile>
+      <Name>FFmpeg HTTP Live Streaming HQ</Name>
+      <Description>High-quality HTTP Live Streaming profile based on ffmpeg</Description>
+      <Bandwidth>896</Bandwidth>
+      <Targets>
+        <Target>android</Target>
+        <Target>ios</Target>
+        <Target>mobile-hls-video</Target>
+      </Targets>
+      <Transport>httplive</Transport>
+      <MaxOutputWidth>800</MaxOutputWidth>
+      <MaxOutputHeight>600</MaxOutputHeight>
+      <MIME>video/MP2T</MIME>
+      <HasVideoStream>true</HasVideoStream>
+
+      <Transcoder>MPExtended.Services.StreamingService.Transcoders.FFMpegWrapperHTTPLiveStreaming</Transcoder>
+      <TranscoderParameters>
+        <codecParameters>-codec:v libx264 -b:v 768k -profile:v baseline -preset:v superfast -coder rle -keyint_min 25 -g 25 -codec:a aac -b:a 128k -ac 2 -strict experimental -async 1 -sn -f segment -segment_list_flags +live -segment_time 5</codecParameters>
+        <httpLiveRemoveOld>5</httpLiveRemoveOld>
+      </TranscoderParameters>
+    </TranscoderProfile>
+    <TranscoderProfile>
+      <Name>FFmpeg HTTP Live Streaming medium</Name>
+      <Description>Medium-quality HTTP Live Streaming profile based on ffmpeg</Description>
+      <Bandwidth>640</Bandwidth>
+      <Targets>
+        <Target>android</Target>
+        <Target>ios</Target>
+        <Target>mobile-hls-video</Target>
+      </Targets>
+      <Transport>httplive</Transport>
+      <MaxOutputWidth>600</MaxOutputWidth>
+      <MaxOutputHeight>400</MaxOutputHeight>
+      <MIME>video/MP2T</MIME>
+      <HasVideoStream>true</HasVideoStream>
+
+      <Transcoder>MPExtended.Services.StreamingService.Transcoders.FFMpegWrapperHTTPLiveStreaming</Transcoder>
+      <TranscoderParameters>
+        <codecParameters>-codec:v libx264 -b:v 512k -profile:v baseline -preset:v superfast -coder rle -keyint_min 25 -g 25 -codec:a aac -b:a 128k -ac 2 -strict experimental -async 1 -sn -f segment -segment_list_flags +live -segment_time 5</codecParameters>
+        <httpLiveRemoveOld>5</httpLiveRemoveOld>
+      </TranscoderParameters>
+    </TranscoderProfile>
+    <TranscoderProfile>
+      <Name>FFmpeg HTTP Live Streaming LQ</Name>
+      <Description>Low-quality HTTP Live Streaming profile based on ffmpeg</Description>
+      <Bandwidth>320</Bandwidth>
+      <Targets>
+        <Target>android</Target>
+        <Target>ios</Target>
+        <Target>mobile-hls-video</Target>
+      </Targets>
+      <Transport>httplive</Transport>
+      <Transport>http</Transport>
+      <MaxOutputWidth>400</MaxOutputWidth>
+      <MaxOutputHeight>300</MaxOutputHeight>
+      <MIME>video/MP2T</MIME>
+      <HasVideoStream>true</HasVideoStream>
+
+      <Transcoder>MPExtended.Services.StreamingService.Transcoders.FFMpegWrapperHTTPLiveStreaming</Transcoder>
+      <TranscoderParameters>
+        <codecParameters>-codec:v libx264 -b:v 256k -profile:v baseline -preset:v ultrafast -coder rle -keyint_min 25 -g 25 -codec:a aac -b:a 64k -ac 1 -strict experimental -async 1 -sn -f segment -segment_list_flags +live -segment_time 5</codecParameters>
+        <httpLiveRemoveOld>5</httpLiveRemoveOld>
+      </TranscoderParameters>
+    </TranscoderProfile>
+    <TranscoderProfile>
+      <Name>FFmpeg HTTP Live Streaming ultra LQ</Name>
+      <Description>Ultra low-quality HTTP Live Streaming profile based on ffmpeg</Description>
+      <Bandwidth>176</Bandwidth>
+      <Targets>
+        <Target>android</Target>
+        <Target>ios</Target>
+        <Target>mobile-hls-video</Target>
+      </Targets>
+      <Transport>httplive</Transport>
+      <MaxOutputWidth>400</MaxOutputWidth>
+      <MaxOutputHeight>300</MaxOutputHeight>
+      <MIME>video/MP2T</MIME>
+      <HasVideoStream>true</HasVideoStream>
+
+      <Transcoder>MPExtended.Services.StreamingService.Transcoders.FFMpegWrapperHTTPLiveStreaming</Transcoder>
+      <TranscoderParameters>
+        <codecParameters>-codec:v libx264 -b:v 128k -profile:v baseline -preset:v ultrafast -coder rle -keyint_min 25 -g 25 -codec:a aac -b:a 48k -ac 1 -strict experimental -async 1 -sn -f segment -segment_list_flags +live -segment_time 5</codecParameters>
+        <httpLiveRemoveOld>5</httpLiveRemoveOld>
+      </TranscoderParameters>
+    </TranscoderProfile>
 
     <!-- Flash streaming for WebMediaPortal -->
     <TranscoderProfile>
@@ -575,6 +702,6 @@
         <encoder>vcodec=none,acodec=mp3,ab=320,channels=2,samplerate=48000</encoder>
         <muxer>:standard{access=file,mux=dummy,dst=#OUT#}</muxer>
       </TranscoderParameters>
-    </TranscoderProfile>
+    </TranscoderProfile>   
   </Transcoders>
 </StreamingProfiles>

--- a/Libraries/LICENSE.txt
+++ b/Libraries/LICENSE.txt
@@ -66,7 +66,7 @@ Streaming\ffmpeg.exe:
 - Licensed under General Public License, version 3, available on http://www.gnu.org/licenses/gpl-3.0.html
 - Source code available from http://ffmpeg.org/, http://git.videolan.org/ffmpeg.git and http://ffmpeg.zeranoe.com/builds/source/ffmpeg/
 - Compiled for Windows by Kyle Schwarz, http://ffmpeg.zeranoe.com/
-- Revision 8293a21a9c80a0cbb753ab44c829c1efff2083e5, static 32-bit build
+- Revision git-c995644 (2012-11-05), static 32-bit build
 
 Streaming\MediaInfo.dll:
 - Copyright (C) 2002-2010 MediaArea.net SARL, Info@MediaArea.net

--- a/Libraries/MPExtended.Libraries.Service/Shared/ChannelLogos.cs
+++ b/Libraries/MPExtended.Libraries.Service/Shared/ChannelLogos.cs
@@ -72,9 +72,12 @@ namespace MPExtended.Libraries.Service.Shared
         public void WriteToCacheDirectory(string channelName, string logoFormat, Stream logo)
         {
             string path = Path.Combine(GetCacheDirectory(), String.Format("{0}.{1}", channelName, logoFormat));
-            using (FileStream writeStream = File.Open(path, FileMode.CreateNew, FileAccess.Write))
+            if (!File.Exists(path))
             {
-                logo.CopyTo(writeStream);
+                using (FileStream writeStream = File.Open(path, FileMode.CreateNew, FileAccess.Write))
+                {
+                    logo.CopyTo(writeStream);
+                }
             }
         }
 

--- a/Services/MPExtended.Services.StreamingService/Code/HTTPLiveStreamer.cs
+++ b/Services/MPExtended.Services.StreamingService/Code/HTTPLiveStreamer.cs
@@ -63,7 +63,7 @@ namespace MPExtended.Services.StreamingService.Code
             return WCFUtil.GetCurrentRoot() + "StreamingService/stream/CustomTranscoderData?identifier=" + Identifier + "&action=playlist&parameters=index.m3u8";
         }
 
-        public Stream ProvideCustomActionFile(string action, string param)
+        public virtual Stream ProvideCustomActionFile(string action, string param)
         {
             switch (action)
             {

--- a/Services/MPExtended.Services.StreamingService/Code/HTTPLiveStreamer.cs
+++ b/Services/MPExtended.Services.StreamingService/Code/HTTPLiveStreamer.cs
@@ -30,7 +30,7 @@ namespace MPExtended.Services.StreamingService.Code
     {
         protected string Identifier { get; set; }
         protected StreamContext Context { get; set; }
-        protected string TemporaryDirectory { get; set; }
+        public string TemporaryDirectory { get; protected set; }
 
         private int keepSegments;
 

--- a/Services/MPExtended.Services.StreamingService/MPExtended.Services.StreamingService.csproj
+++ b/Services/MPExtended.Services.StreamingService/MPExtended.Services.StreamingService.csproj
@@ -82,6 +82,8 @@
     <Compile Include="MediaInfo\IMediaInfoCache.cs" />
     <Compile Include="MediaInfo\XmlCache.cs" />
     <Compile Include="Code\HTTPLiveStreamer.cs" />
+    <Compile Include="Transcoders\FFMpegHTTPLiveStreamer.cs" />
+    <Compile Include="Transcoders\FFMpegWrapperHTTPLiveStreaming.cs" />
     <Compile Include="Transcoders\Generic.cs" />
     <Compile Include="Transcoders\IRetrieveHookTranscoder.cs" />
     <Compile Include="MediaInfo\MediaInfo.cs" />

--- a/Services/MPExtended.Services.StreamingService/Transcoders/FFMpeg.cs
+++ b/Services/MPExtended.Services.StreamingService/Transcoders/FFMpeg.cs
@@ -53,7 +53,7 @@ namespace MPExtended.Services.StreamingService.Transcoders
                 Context.Pipeline.AddDataUnit(Context.Source.GetInputReaderUnit(), 1);
             }
 
-            string arguments = GenerateFFMpegArguments();
+            string arguments = GenerateArguments();
 
             // fix input thing
             if (!doInputReader)
@@ -73,7 +73,7 @@ namespace MPExtended.Services.StreamingService.Transcoders
             Context.Pipeline.AddLogUnit(logunit, 6);
         }
 
-        public virtual string GenerateFFMpegArguments()
+        public virtual string GenerateArguments()
         {
             // calculate stream mappings (no way I'm going to add subtitle support; it's just broken)
             string mappings = "";

--- a/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegHTTPLiveStreamer.cs
+++ b/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegHTTPLiveStreamer.cs
@@ -5,7 +5,6 @@ using System.Text;
 using MPExtended.Services.StreamingService.Code;
 using System.IO;
 using MPExtended.Libraries.Service;
-using System.Text.RegularExpressions;
 
 namespace MPExtended.Services.StreamingService.Transcoders
 {

--- a/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegHTTPLiveStreamer.cs
+++ b/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegHTTPLiveStreamer.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using MPExtended.Services.StreamingService.Code;
+using System.IO;
+using MPExtended.Libraries.Service;
+using System.Text.RegularExpressions;
+
+namespace MPExtended.Services.StreamingService.Transcoders
+{
+    class FFMpegHTTPLiveStreamer : HTTPLiveStreamer
+    {
+        string indexUrl;
+        public FFMpegHTTPLiveStreamer(string identifier, StreamContext context)
+            : base(identifier, context)
+        {
+            indexUrl = WCFUtil.GetCurrentRoot() + "StreamingService/stream/CustomTranscoderData?identifier=" + identifier + "&action=segment&parameters=";            
+        }
+
+        public string GetTemporaryDirectory()
+        {
+            return TemporaryDirectory;
+        }
+
+        public override Stream ProvideCustomActionFile(string action, string param)
+        {
+            if (action == "playlist")
+            {
+                WCFUtil.SetContentType("application/vnd.apple.mpegurl");
+                string playlistPath = Path.Combine(TemporaryDirectory, "index.m3u8");
+                if (!File.Exists(playlistPath))
+                {
+                    Log.Warn("HTTPLiveStreamer: Client requested index.m3u8 that doesn't exist for identifier '{0}'", Identifier);
+                    return Stream.Null;
+                }
+                //FFMpeg outputs the local segment paths in the playlist, replace with url
+                string playlist = replacePathsWithURLs(playlistPath);
+                if (playlist == string.Empty)
+                {
+                    //the playlist file is empty until the first segment has finished being encoded,
+                    //wait for next segment to begin and retry
+                    string segmentPath = Path.Combine(TemporaryDirectory, "000001.ts");
+                    while (!File.Exists(segmentPath))
+                        System.Threading.Thread.Sleep(100);
+                    playlist = replacePathsWithURLs(playlistPath);
+                }
+                return new MemoryStream(Encoding.UTF8.GetBytes(playlist));
+            }
+
+            return base.ProvideCustomActionFile(action, param);
+        }
+
+        string replacePathsWithURLs(string path)
+        {
+            // open original file, but retry if we fail with an IOException, which might happen because VLC is still writing to it
+            FileStream fileStream = null;
+            try
+            {
+                fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            }
+            catch (IOException)
+            {
+                System.Threading.Thread.Sleep(20);
+                fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            }
+
+            string playlist = "";
+            using (StreamReader reader = new StreamReader(fileStream, Encoding.UTF8))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (line != string.Empty && !line.StartsWith("#"))
+                    {
+                        //ensure that segment path has been completely written so it is correctly replaced and we don't expose system paths to web
+                        if (!line.StartsWith(TemporaryDirectory))
+                            break;
+                        //replace local path with url
+                        line = indexUrl + line.Replace(TemporaryDirectory, "").Replace("\\", "");
+                    }
+                    playlist += line + "\n";
+                }
+            }
+            return playlist;
+        }
+    }
+}

--- a/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegHTTPLiveStreamer.cs
+++ b/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegHTTPLiveStreamer.cs
@@ -17,11 +17,6 @@ namespace MPExtended.Services.StreamingService.Transcoders
             indexUrl = WCFUtil.GetCurrentRoot() + "StreamingService/stream/CustomTranscoderData?identifier=" + identifier + "&action=segment&parameters=";            
         }
 
-        public string GetTemporaryDirectory()
-        {
-            return TemporaryDirectory;
-        }
-
         public override Stream ProvideCustomActionFile(string action, string param)
         {
             if (action == "playlist")
@@ -52,18 +47,7 @@ namespace MPExtended.Services.StreamingService.Transcoders
 
         string replacePathsWithURLs(string path)
         {
-            // open original file, but retry if we fail with an IOException, which might happen because VLC is still writing to it
-            FileStream fileStream = null;
-            try
-            {
-                fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            }
-            catch (IOException)
-            {
-                System.Threading.Thread.Sleep(20);
-                fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            }
-
+            FileStream fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);            
             string playlist = "";
             using (StreamReader reader = new StreamReader(fileStream, Encoding.UTF8))
             {

--- a/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegWrapperHTTPLiveStreaming.cs
+++ b/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegWrapperHTTPLiveStreaming.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using MPExtended.Services.StreamingService.Code;
+using MPExtended.Services.StreamingService.Units;
+using MPExtended.Libraries.Service;
+using System.IO;
+
+namespace MPExtended.Services.StreamingService.Transcoders
+{
+    internal class FFMpegWrapperHTTPLiveStreaming: FFMpeg, ICustomActionTranscoder
+    {
+        FFMpegHTTPLiveStreamer httpLive;
+        public FFMpegWrapperHTTPLiveStreaming()
+            : base()
+        {
+            ReadOutputStream = false;
+        }
+
+        public override string GetStreamURL()
+        {
+            return httpLive.GetStreamURL();
+        }
+
+        public override void BuildPipeline()
+        {
+            httpLive = new FFMpegHTTPLiveStreamer(Identifier, Context); 
+            base.BuildPipeline();
+            httpLive.AppendPipeline();
+        }
+
+        public override string GenerateFFMpegArguments()
+        {
+            string arguments = base.GenerateFFMpegArguments();
+            string outputDirectory = httpLive.GetTemporaryDirectory();
+            string playlist = Path.Combine(outputDirectory, "index.m3u8");
+            string segment = Path.Combine(outputDirectory, "%06d.ts");
+            return string.Format("{0} -segment_list \"{1}\" \"{2}\"", arguments, playlist, segment);            
+        }
+
+        #region ICustomActionTranscoder Members
+
+        public System.IO.Stream CustomActionData(string action, string parameters)
+        {
+            return httpLive.ProvideCustomActionFile(action, parameters);
+        }
+
+        #endregion
+    }
+}

--- a/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegWrapperHTTPLiveStreaming.cs
+++ b/Services/MPExtended.Services.StreamingService/Transcoders/FFMpegWrapperHTTPLiveStreaming.cs
@@ -30,10 +30,10 @@ namespace MPExtended.Services.StreamingService.Transcoders
             httpLive.AppendPipeline();
         }
 
-        public override string GenerateFFMpegArguments()
+        public override string GenerateArguments()
         {
-            string arguments = base.GenerateFFMpegArguments();
-            string outputDirectory = httpLive.GetTemporaryDirectory();
+            string arguments = base.GenerateArguments();
+            string outputDirectory = httpLive.TemporaryDirectory;
             string playlist = Path.Combine(outputDirectory, "index.m3u8");
             string segment = Path.Combine(outputDirectory, "%06d.ts");
             return string.Format("{0} -segment_list \"{1}\" \"{2}\"", arguments, playlist, segment);            


### PR DESCRIPTION
I find the VLC encoding a bit ropey so I've added FFMpeg support for HLS streams.

I also fixed a potential fatal exception when writing a channel logo to the cache if you have more than one channel with the same name
