### PR TITLE
MPMusic: Sorting by MusicTrackNumber now reflects disc number

### DIFF
--- a/PlugIns/MPExtended.PlugIns.MAS.MPMusic/MPMusic.cs
+++ b/PlugIns/MPExtended.PlugIns.MAS.MPMusic/MPMusic.cs
@@ -57,7 +57,7 @@ namespace MPExtended.PlugIns.MAS.MPMusic
             Dictionary<string, WebMusicArtistBasic> artists = null;
             Dictionary<Tuple<string, string>, IList<WebArtworkDetailed>> artwork = new Dictionary<Tuple<string, string>, IList<WebArtworkDetailed>>();
 
-            string sql = "SELECT idTrack, strAlbumArtist, strAlbum, strArtist, iTrack, strTitle, strPath, iDuration, iYear, strGenre, iRating " +
+            string sql = "SELECT idTrack, strAlbumArtist, strAlbum, strArtist, iDisc, iTrack, strTitle, strPath, iDuration, iYear, strGenre, iRating " +
                          "FROM tracks t " +
                          "WHERE %where";
             return new LazyQuery<T>(this, sql, new List<SQLFieldMapping>() {
@@ -69,6 +69,7 @@ namespace MPExtended.PlugIns.MAS.MPMusic
                 new SQLFieldMapping("t", "strAlbum", "Album", DataReaders.ReadString),
                 new SQLFieldMapping("t", "strAlbum", "AlbumId", AlbumIdReader),
                 new SQLFieldMapping("t", "strTitle", "Title", DataReaders.ReadString),
+                new SQLFieldMapping("t", "iDisc", "DiscNumber", DataReaders.ReadInt32),
                 new SQLFieldMapping("t", "iTrack", "TrackNumber", DataReaders.ReadInt32),
                 new SQLFieldMapping("t", "strPath", "Path", DataReaders.ReadStringAsList),
                 new SQLFieldMapping("t", "strGenre", "Genres", DataReaders.ReadPipeList),

--- a/Services/MPExtended.Services.MediaAccessService.Interfaces/Music/WebMusicTrackBasic.cs
+++ b/Services/MPExtended.Services.MediaAccessService.Interfaces/Music/WebMusicTrackBasic.cs
@@ -20,6 +20,7 @@ namespace MPExtended.Services.MediaAccessService.Interfaces.Music
         public IList<string> ArtistId { get; set; }
         public string Album { get; set; }
         public string AlbumId { get; set; }
+        public int DiscNumber { get; set; }
         public int TrackNumber { get; set; }
         public int Year { get; set; }
         public int Duration { get; set; }

--- a/Services/MPExtended.Services.MediaAccessService.Interfaces/SortInterfaces.cs
+++ b/Services/MPExtended.Services.MediaAccessService.Interfaces/SortInterfaces.cs
@@ -39,6 +39,7 @@ namespace MPExtended.Services.MediaAccessService.Interfaces
     public interface IMusicTrackNumberSortable 
     {
         int TrackNumber { get; set; }
+        int DiscNumber { get; set; }
     }
 
     public interface IMusicComposerSortable

--- a/Services/MPExtended.Services.MediaAccessService/ExtensionMethods.cs
+++ b/Services/MPExtended.Services.MediaAccessService/ExtensionMethods.cs
@@ -104,7 +104,7 @@ namespace MPExtended.Services.MediaAccessService
 
                     // music
                     case WebSortField.MusicTrackNumber:
-                        return list.OrderBy(x => ((IMusicTrackNumberSortable)x).TrackNumber, order);
+                        return list.OrderBy(x => ((IMusicTrackNumberSortable)x).DiscNumber, order).ThenBy(x => ((IMusicTrackNumberSortable)x).TrackNumber, order);
                     case WebSortField.MusicComposer:
                         return list.OrderBy(x => ((IMusicComposerSortable)x).Composer.First(), order);
 


### PR DESCRIPTION
Similarly as with TVEpisodeNumber where sorting has to count also with seasons, MusicTrackNumber so far did not take into account that multi-disc albums, when properly tagged (DISCNUMBER ID3 tag), require to be sorted with respect to the disc number. This can be accomplished by sorting the query output from MP MusicDatabase based on iDisc value first. 

Tested & works fine
