### PR TITLE
Changed sgen build to use SDK40ToolsPath

### DIFF
--- a/Libraries/MPExtended.Libraries.Service.Config/MPExtended.Libraries.Service.Config.csproj
+++ b/Libraries/MPExtended.Libraries.Service.Config/MPExtended.Libraries.Service.Config.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"$(FrameworkSDKDir)Bin\NETFX 4.0 Tools\sgen.exe" "/assembly:$(TargetPath)" /force</PostBuildEvent>
+    <PostBuildEvent>"$(SDK40ToolsPath)sgen.exe" "/assembly:$(TargetPath)" /force</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
0.6 release doesn't build in Visual Studio 2013.

Fixed as per http://connect.microsoft.com/VisualStudio/feedback/details/811986/-frameworksdkdir-value-in-vs-macros-post-build-event-references-invalid-path
